### PR TITLE
Fix for AnimationDefs build

### DIFF
--- a/SamplesContentBuilder/SamplesContentBuilderContent/SamplesContentBuilderContent.contentproj
+++ b/SamplesContentBuilder/SamplesContentBuilderContent/SamplesContentBuilderContent.contentproj
@@ -988,11 +988,12 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Textures\Catapults\AnimationsDef.xml">
+    <Content Include="Textures\Catapults\AnimationsDef.xml">
       <Name>AnimationsDef</Name>
       <Importer>XmlImporter</Importer>
       <Processor>PassThroughProcessor</Processor>
-    </Compile>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="bonus\Apple.png">


### PR DESCRIPTION
This changes the build for AnimationsDefs.xml to be content and to always output to the target directory as raw data.
