### PR TITLE
Resolving No class named AppDelegate is loaded exception

### DIFF
--- a/GameStateManagement/Program.cs
+++ b/GameStateManagement/Program.cs
@@ -63,7 +63,7 @@ namespace GameStateManagement
         /// </summary>
         static void Main(string[] args)
         {
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, "UIApplication", "AppDelegate");
         }
     }    
 #elif MONOMAC


### PR DESCRIPTION
RE: https://github.com/mono/MonoGame/issues/959

```
           // generates an exception
           UIApplication.Main(args, null , "AppDelegate"); 
```

but

```
           // works
           UIApplication.Main(args, "UIApplication" , "AppDelegate"); 
```
