### PR TITLE
Fix V3076

### DIFF
--- a/NetRumble/Gameplay/GameplayObject.cs
+++ b/NetRumble/Gameplay/GameplayObject.cs
@@ -55,7 +55,7 @@ namespace NetRumble
             get { return velocity; }
             set 
             {
-                if ((value.X == Single.NaN) || (value.Y == Single.NaN))
+                if (Single.IsNaN(value.X) || Single.IsNaN(value.Y))
                 {
                     throw new ArgumentException("Velocity was NaN");
                 }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bugs, found using PVS-Studio:

- V3076 Comparison of 'value.X' with 'float.NaN' is meaningless. Use 'float.IsNaN()' method instead. GameplayObject.cs 58

- V3076 Comparison of 'value.Y' with 'float.NaN' is meaningless. Use 'float.IsNaN()' method instead. GameplayObject.cs 58

 As stated in the documentation, if two double.NaN/single.NaN/float.NaN  values are tested for equality by using the == operator, the result is false. So, no matter what value of type double/single/float is compared with double.NaN/single.NaN/float.NaN, the result is always false.

